### PR TITLE
Encryption key setup

### DIFF
--- a/lib/encryption_key.rb
+++ b/lib/encryption_key.rb
@@ -2,7 +2,6 @@ class EncryptionKey
   attr_reader :date
   def initialize(date)
     @date = date
-
   end
 
   def random_number_generator

--- a/lib/encryption_key.rb
+++ b/lib/encryption_key.rb
@@ -1,6 +1,6 @@
 class EncryptionKey
   attr_reader :date
-  def initialize(date)
+  def initialize(date = Time.now.strftime("%d%m%y"))
     @date = date
   end
 

--- a/test/encryption_key_test.rb
+++ b/test/encryption_key_test.rb
@@ -38,4 +38,10 @@ class EncryptionKeyTest < MiniTest::Test
     encryption_key.stubs(:random_number_generator).returns([1,2,3,4,5])
     assert_equal expected, encryption_key.offset_maker
   end
+
+  def test_default_date
+    enigma_key = EncryptionKey.new
+    assert_instance_of EncryptionKey, enigma_key
+    assert_equal "041119", enigma_key.date
+  end
 end


### PR DESCRIPTION
Refactor date parameter to include default of today's date if not provided. If date changes, test for date default will fail, but just needs to be updated to match current date.